### PR TITLE
Update UUID to prevent collision

### DIFF
--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -31,6 +31,6 @@
 		</array>
 	</dict>
 	<key>uuid</key>
-	<string>A67A8BD9-A951-406F-9175-018DD4B52FD1</string>
+	<string>212429B0-6FB2-435E-BA90-D130F2ABF8F1</string>
 </dict>
 </plist>


### PR DESCRIPTION
This is the same UUID as the base JavaScript bundle from TextMate, changed to prevent conflicting.
