### PR TITLE
Add support for superclass after `extends`.

### DIFF
--- a/Syntaxes/JavaScript (Babel).tmLanguage
+++ b/Syntaxes/JavaScript (Babel).tmLanguage
@@ -1499,6 +1499,20 @@
 									<key>include</key>
 									<string>#expression</string>
 								</dict>
+								<dict>
+									<key>begin</key>
+									<string>\s+([_$a-zA-Z][$\w]*)</string>
+									<key>beginCaptures</key>
+									<dict>
+										<key>1</key>
+										<dict>
+											<key>name</key>
+											<string>entity.name.class.js</string>
+										</dict>
+									</dict>
+									<key>end</key>
+									<string>(?={)</string>
+								</dict>
 							</array>
 						</dict>
 						<dict>


### PR DESCRIPTION
```js
class Sub extends Super {
                  ^^^^^
```